### PR TITLE
Ja es poden penjar imatges des del Kivy (PY-13)

### DIFF
--- a/app/Http/Controllers/ImageDeviceController.php
+++ b/app/Http/Controllers/ImageDeviceController.php
@@ -23,24 +23,25 @@ class ImageDeviceController extends Controller
     }
 
     public function guardar(Request $request) {
-
         // Validem que la imatge sigui correcta
         $request->validate([
             'files.*' => 'image|mimes:png,jpg,jpeg|max:2048'
         ]);
-
+        
         // Guardem l'arxiu i recuperem la ruta
         $files = $request->file('files');
-        //Storage::disk('local')->put('test', $files);
+        
+        if (is_array($files)) foreach ($files as $file) $this->save_image($file);
+        else $this->save_image($files);
+    }
 
-        foreach ($files as $file) {
-            $route = $file->store('public/images');
-
-            // Guardem a la base de dades la ruta a aquesta imatge
-            ImageDevice::create([
-                'location' => 'storage/' . substr($route, 7), // eliminem "public/" de la ruta
-                'device_id' => 1
-            ]);
-        }
+    private function save_image($file) {
+        $route = $file->store('public/images');
+    
+        // Guardem a la base de dades la ruta a aquesta imatge
+        ImageDevice::create([
+            'location' => 'storage/' . substr($route, 7), // eliminem "public/" de la ruta
+            'device_id' => 1
+        ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\QuestionnaireController;
 use App\Http\Controllers\QuestionController;
 use App\Http\Controllers\ReportController;
 use App\Http\Controllers\CourseController;
+use App\Http\Controllers\ImageDeviceController;
 
 /*
 |--------------------------------------------------------------------------
@@ -88,7 +89,7 @@ Route::put('/update-task/{id}', [BudgetController::class, 'updateSingleTask'])->
 
 /** ----- EQUIP 5 ------ */
 Route::post('/devices/delete', [DevicesController::class, 'delete']);
-Route::post('/image', [InventoryController::class, 'uploadImage']);
+Route::post('/image', [ImageDeviceController::class, 'guardar']);
 
 /** -- kivy equip 2 */
 Route::get('kivy/json', [QuestionnaireController::class, 'indexmobil']);


### PR DESCRIPTION
Aquesta Pull Request adreça la tasca PY-13, que permet penjar imatges des del Kivy.

Bàsicament, el mètode guardar del control·lador ImageDeviceController accepta tant una array com una imatge sola, i la guarda.